### PR TITLE
railsadmin implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'webpacker'
 gem 'devise'
 gem 'activeadmin', github: 'activeadmin/activeadmin'
 gem 'inherited_resources', github: 'activeadmin/inherited_resources'
+gem 'remotipart', github: 'mshibuya/remotipart'
+gem 'rails_admin', '>= 1.0.0.rc'
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,12 @@ GIT
       railties (>= 4.2, < 5.3)
       responders
 
+GIT
+  remote: git://github.com/mshibuya/remotipart.git
+  revision: e08ea9a3aa8db9a8b2b97b6c9e7b078ed08915f2
+  specs:
+    remotipart (1.4.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -88,6 +94,13 @@ GEM
     builder (3.2.3)
     byebug (10.0.2)
     coderay (1.1.2)
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
     devise (4.5.0)
@@ -103,6 +116,8 @@ GEM
     erubi (1.7.1)
     execjs (2.7.0)
     ffi (1.9.25)
+    font-awesome-rails (4.7.0.4)
+      railties (>= 3.2, < 6.0)
     font-awesome-sass (5.0.13)
       sassc (>= 1.11)
     formtastic (3.1.5)
@@ -110,6 +125,9 @@ GEM
     formtastic_i18n (0.6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    haml (5.0.4)
+      temple (>= 0.8.0)
+      tilt
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
@@ -122,6 +140,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (6.0.1)
+      railties (>= 3.2.16)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -151,6 +171,7 @@ GEM
     minitest (5.11.3)
     msgpack (1.2.4)
     multi_json (1.13.1)
+    nested_form (0.3.2)
     nio4r (2.3.1)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
@@ -166,6 +187,9 @@ GEM
       pry (>= 0.10.4)
     puma (3.12.0)
     rack (2.0.5)
+    rack-pjax (1.0.0)
+      nokogiri (~> 1.5)
+      rack (>= 1.1)
     rack-proxy (0.6.4)
       rack
     rack-test (1.1.0)
@@ -188,6 +212,19 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails_admin (1.4.1)
+      builder (~> 3.1)
+      coffee-rails (~> 4.0)
+      font-awesome-rails (>= 3.0, < 5)
+      haml (>= 4.0, < 6)
+      jquery-rails (>= 3.0, < 5)
+      jquery-ui-rails (>= 5.0, < 7)
+      kaminari (>= 0.14, < 2.0)
+      nested_form (~> 0.3)
+      rack-pjax (>= 0.7)
+      rails (>= 4.0, < 6)
+      remotipart (~> 1.3)
+      sass-rails (>= 4.0, < 6)
     railties (5.2.1)
       actionpack (= 5.2.1)
       activesupport (= 5.2.1)
@@ -240,6 +277,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -281,7 +319,9 @@ DEPENDENCIES
   pry-rails
   puma
   rails (= 5.2.1)
+  rails_admin (>= 1.0.0.rc)
   redis
+  remotipart!
   sass-rails
   simple_form
   spring

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,45 @@
+RailsAdmin.config do |config|
+
+  config.authorize_with do |controller|
+    redirect_to main_app.root_path unless current_user && current_user.admin
+  end
+
+  ### Popular gems integration
+
+  ## == Devise ==
+  # config.authenticate_with do
+  #   warden.authenticate! scope: :user
+  # end
+  # config.current_user_method(&:current_user)
+
+  ## == Cancan ==
+  # config.authorize_with :cancan
+
+  ## == Pundit ==
+  # config.authorize_with :pundit
+
+  ## == PaperTrail ==
+  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
+
+  ### More at https://github.com/sferik/rails_admin/wiki/Base-configuration
+
+  ## == Gravatar integration ==
+  ## To disable Gravatar integration in Navigation Bar set to false
+  # config.show_gravatar = true
+
+  config.actions do
+    dashboard                     # mandatory
+    index                         # mandatory
+    new
+    export
+    bulk_delete
+    show
+    edit
+    delete
+    show_in_app
+
+    ## With an audit adapter, you can add:
+    # history_index
+    # history_show
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount RailsAdmin::Engine => '/ecrire', as: 'rails_admin'
   ActiveAdmin.routes(self)
   devise_for :users
   root to: 'pages#home'


### PR DESCRIPTION
c'est une autre gem pour l'admin, celle-ci est plus sympa, accessible sur http://localhost:3000/ecrire

La différence avec l'autre c'est que tous les modèles sont importés par défaut, et donc toutes les personnes qui ont accès a railsadmin peuvent effectuer toutes les manips (ex : supprimer tous les users), mais pour des devs averti ça fait l'affaire ! : ) 

Meme principe : 

1. Sign up : http://localhost:3000/ecrire
2. Se rendre dans la console ```rails c``` et 
```user = User.last``` 
```user.admin = true```
```user.save```
3. l'admin est maintenant accessible à  http://localhost:3000/ecrire

![image](https://user-images.githubusercontent.com/37231983/44659038-22301380-aa03-11e8-8444-6a67ba872929.png)

une fois mergé, pas oublier de 

``` bundle install ```
``` yarn install ```
``` rails db:migrate ``` 